### PR TITLE
setting properties file amend

### DIFF
--- a/src/EasyAbp.Abp.SettingUi.Application/SettingUiAppService.cs
+++ b/src/EasyAbp.Abp.SettingUi.Application/SettingUiAppService.cs
@@ -131,7 +131,11 @@ namespace EasyAbp.Abp.SettingUi
                     var properties = settingProperties[si.Name];
                     foreach (var kv in properties)
                     {
-                        si.WithProperty(kv.Key, kv.Value);
+                        // Do not assign the property if it has already been set by the user.
+                        if (!si.Properties.ContainsKey(kv.Key))
+                        {
+                            si.WithProperty(kv.Key, kv.Value);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Remove the SettingProperty 'Type': 'Text', as the SettingUi can provide the default value: 'text' if the file not provided.
There is a scene, I want to amend the settingproperties of "Abp.Localization.DefaultLanguage" , like "Type" to "select", as the implementation, if the setting properties file provide the "Type" => "text", the "select" would be override to "text", this is not the result I want.